### PR TITLE
Fix fatalErrors by adding Swift errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
-osx_image: xcode7.2
+osx_image: xcode9.0
 language: objective-c
 script: xctool -scheme SwiftRouter -sdk iphonesimulator test -test-sdk iphonesimulator9.2 -freshInstall -freshSimulator

--- a/Example/SwiftRouterExample.xcodeproj/project.pbxproj
+++ b/Example/SwiftRouterExample.xcodeproj/project.pbxproj
@@ -268,6 +268,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = cn.edu.hit.www.SwiftRouterExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -279,6 +280,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = cn.edu.hit.www.SwiftRouterExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/Example/SwiftRouterExample/AppDelegate.swift
+++ b/Example/SwiftRouterExample/AppDelegate.swift
@@ -14,32 +14,32 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
 
-    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
         // Override point for customization after application launch.
         let router = Router.sharedInstance
         router.map("/user/:userId", controllerClass: UserViewController.self)
         return true
     }
 
-    func applicationWillResignActive(application: UIApplication) {
+    func applicationWillResignActive(_ application: UIApplication) {
         // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
         // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
     }
 
-    func applicationDidEnterBackground(application: UIApplication) {
+    func applicationDidEnterBackground(_ application: UIApplication) {
         // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
         // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
     }
 
-    func applicationWillEnterForeground(application: UIApplication) {
+    func applicationWillEnterForeground(_ application: UIApplication) {
         // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering the background.
     }
 
-    func applicationDidBecomeActive(application: UIApplication) {
+    func applicationDidBecomeActive(_ application: UIApplication) {
         // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
     }
 
-    func applicationWillTerminate(application: UIApplication) {
+    func applicationWillTerminate(_ application: UIApplication) {
         // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
     }
 

--- a/Example/SwiftRouterExample/ViewController.swift
+++ b/Example/SwiftRouterExample/ViewController.swift
@@ -15,8 +15,8 @@ class ViewController: UIViewController {
     @IBOutlet weak var textField: UITextField!
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.routeButton.addTarget(self, action: "doRoute", forControlEvents: UIControlEvents.TouchDown)
-        self.clearButton.addTarget(self, action: "doClear", forControlEvents: UIControlEvents.TouchDown)
+        self.routeButton.addTarget(self, action: #selector(doRoute), for: UIControlEvents.touchDown)
+        self.clearButton.addTarget(self, action: #selector(doClear), for: UIControlEvents.touchDown)
         // Do any additional setup after loading the view, typically from a nib.
     }
 

--- a/Example/SwiftRouterExample/ViewController.swift
+++ b/Example/SwiftRouterExample/ViewController.swift
@@ -22,7 +22,7 @@ class ViewController: UIViewController {
 
     func doRoute() {
         if let url = self.textField.text {
-            Router.sharedInstance.routeURL(url, navigationController: self.navigationController!)
+            try? Router.shared.routeURL(url, navigationController: self.navigationController!)
         }
     }
 


### PR DESCRIPTION
This PR fixes `fatalError`s which are routinely encountered in unrecognized routes.

It has a breaking API change, which may not be acceptable to existing clients.

The tests and example project has been updated to reflect these changes.