### PR TITLE
Fix router instance reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Map URL to ViewController:
 ```swift
 import SwiftRouter
 
-let router = Router.sharedInstance
+let router = Router.shared
 router.map("/user/:userId", controllerClass: UserViewController.self)
 ```
 


### PR DESCRIPTION
Shared router instance refers to wrong variable name in readme. The name used in readme seems to be a better option though but since changing the reference in code can break usage, changed the readme instead